### PR TITLE
chore(index.astro): fix typos, phrasing, punctuation

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -11,7 +11,7 @@ interface Props {
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
-const { title = 'TresJS', description = 'Declarative ThreeJS using Vue Components', image = '/og.png' } = Astro.props;
+const { title = 'TresJS', description = 'Declarative Three.js using Vue Components', image = '/og.png' } = Astro.props;
 const ogImage = image.src || new URL(image, Astro.url) ;
 ---
 

--- a/src/components/CommunityWordSection.astro
+++ b/src/components/CommunityWordSection.astro
@@ -15,7 +15,7 @@ const testimonials = await Promise.all(items.map(async (item) => {
 <section class="bg-grid min-h-screen snap-start text-gray-500 flex justify-center items-center pt-16">
   <div class="container mx-auto">
     <h2 class="important-text-4xl mb-32 dark:text-light  opacity-0 animate-fade-in animate-delay-1s animate-forwards">
-      Take the word from the <strong class="text-primary-300">community</strong>.
+      Take the <strong class="text-primary-300">community’s</strong> word for it
     </h2>
 
     <div class="masonry">

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -7,7 +7,7 @@ import InitCommand from "./InitCommand.vue";
   <div class="mx-auto container">
     <div class="w-full md:w-1/2">
       <h2 class="important-text-4xl text-gray-500 dark:text-light mt-32 sm:mt-0 mb-8 opacity-0 animate-fade-in animate-delay-1s animate-forwards">
-        Create awesome 3D experiences with <strong class="text-primary-300">Vue</strong>.
+        Create awesome 3D experiences with <strong class="text-primary-300">Vue</strong>
        <!--  Wait for <strong class="text-primary-300">29/11/2023</strong> 🤭 -->
       </h2>
       <div class="flex flex-col sm:flex-row gap-4">

--- a/src/components/ShowcaseSection.astro
+++ b/src/components/ShowcaseSection.astro
@@ -10,10 +10,10 @@ const showcaseEntries = await getCollection('showcase');
 <section class="min-h-screen snap-start text-gray-500 flex justify-center items-center py-16">
   <div class="container mx-auto dark:text-light">
     <h2 class="important-text-4xl mb-8 opacity-0 animate-fade-in animate-delay-1s animate-forwards">
-      Showcase your <strong class="text-primary-300">work</strong>.
+      Showcase your <strong class="text-primary-300">work</strong>
     </h2>
     <p class="opacity-0 animate-fade-in animate-delay-1.25s animate-forwards">
-      Be part of the a big community of creators and 3D entusiasts
+      Be part of a big community of creators and 3D enthusiasts.
     </p>
 
     <div class="grid

--- a/src/components/TechStackSection.astro
+++ b/src/components/TechStackSection.astro
@@ -1,11 +1,11 @@
 <section id="techstack-section" class="min-h-screen snap-start flex justify-center items-center pt-16">
   <div class="container w-full mx-auto flex-col text-center justify-center">
     <h3 class="text-primary-300 font-bold text-4xl sm:text-6xl mb-16 opacity-0">
-      Build 3D with Vue 
+      Build 3D with Vue
     </h3>
     <p class="text-gray-400 text-center text-base sm:text-lg mb-16 opacity-0">
-    TresJS reduces the gap between the developers and the intimidating world of 3D </br>
-A custom render for ThreeJS powered by Vite.
+    TresJS reduces the gap between the developers and the intimidating world of 3D.</br>
+A custom renderer for Three.js powered by Vite.
     <ul class="flex justify-center gap-16 mx-auto">
       <li class="bg-gray-200 flex-inline rounded-full text-2xl sm:text-4xl p-3 sm:p-6 opacity-0">
         <i class="i-logos-vue" />

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -2,4 +2,4 @@
 // You can import this data from anywhere in your site by using the `import` keyword.
 
 export const SITE_TITLE = 'TresJS';
-export const SITE_DESCRIPTION = 'Declarative ThreeJS using Vue Components';
+export const SITE_DESCRIPTION = 'Declarative Three.js using Vue Components';

--- a/src/content/section/declarative-scenes.md
+++ b/src/content/section/declarative-scenes.md
@@ -4,5 +4,5 @@ link: https://tresjs.org/guide/your-first-scene.html
 
 # Declarative <br/> <span class="text-primary-300">Scenes</span>
 
-TresJS enables you to utilise all capabilities of Three.js declaratively by using vue components, and let `<TresCanvas />` manage the rest. Utilise the lifecycle of Vue components to engage with events, manage state transitions.
+TresJS enables you to utilise all capabilities of Three.js declaratively by using Vue components and let `<TresCanvas />` manage the rest. Utilise the lifecycle of Vue components to engage with events and manage state transitions.
 

--- a/src/content/section/dx-focused.md
+++ b/src/content/section/dx-focused.md
@@ -2,7 +2,7 @@
 link: https://tresjs.org/guide/your-first-scene.html
 ---
 
-# <span class="text-primary-300">DX</span> focused Ecosystem
+# <span class="text-primary-300">DX</span>-focused Ecosystem
 
 Expand the core capabilities with packages like `cientos` and `post-processing` to reduce the 🍝 code for tasks like handling 3D Models or adding camera controls.
 

--- a/src/content/showcase/synthwave.md
+++ b/src/content/showcase/synthwave.md
@@ -1,9 +1,9 @@
 ---
-title: Procedural Syntwave
+title: Procedural Synthwave
 date: Nov 28 2023
 thumbnail: ../assets/showcase/synthwave.png
 demo: https://playground.tresjs.org/experiments/synthwave
-author: Peter Moldovia
+author: André Tchen
 author_link: https://github.com/andretchen0
 avatar: ../assets/avatars/andretchen0.png
 status: Published

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,7 +27,6 @@ import SponsorsSection from '../components/SponsorsSection.astro';
 				<DeclarativeScenes  />
 				<DxFocusedSection />
 				<ShowcaseSection />
-				<SponsorsSection />
 				<CommunityWordSection />
 			</main>
 			<Footer />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,6 +27,7 @@ import SponsorsSection from '../components/SponsorsSection.astro';
 				<DeclarativeScenes  />
 				<DxFocusedSection />
 				<ShowcaseSection />
+				<SponsorsSection />
 				<CommunityWordSection />
 			</main>
 			<Footer />


### PR DESCRIPTION
Just cleaning up a few typos and punctuation inconsistencies on the landing page.

In particular:

* Change variations of "ThreeJS" -> "Three.js"
* Change "vue" -> "Vue"
* Removed periods from titles, when they were present. (This seems to be the same policy Vue uses for their docs, as far as I can see.)
* Inserted periods if they were missing after complete sentences in body text. (Unless an emoji was used at the end of the sentence.)

I also changed my handle on the "procedural synthwave" demo.

(FWIW, I couldn't get the project to display without error as long as `<SponsorSection />` was in `index.astro`. I removed the section while developing, but then added it back in the last commit.)