### PR TITLE
docs: fix broken link, author name

### DIFF
--- a/src/content/showcase/synthwave.md
+++ b/src/content/showcase/synthwave.md
@@ -2,8 +2,8 @@
 title: Procedural Synthwave
 date: Nov 28 2023
 thumbnail: ../assets/showcase/synthwave.png
-demo: https://playground.tresjs.org/experiments/synthwave
-author: André Tchen
+demo: https://lab.tresjs.org/experiments/synthwave
+author: andretchen0
 author_link: https://github.com/andretchen0
 avatar: ../assets/avatars/andretchen0.png
 status: Published


### PR DESCRIPTION
## Problem

A link to a showcase entry has the wrong URL. [Reported in this comment.](https://github.com/Tresjs/tres/issues/676#issuecomment-2106365010)

## Solution

Fix the link. And fix author name.

## Related

I can't get the docs preview running at the moment – Astro 404s. So I can't verify that the updated URL is actually shown. (Any pointers would be appreciated.)

<img width="819" alt="Screenshot 2024-05-12 at 22 40 13" src="https://github.com/Tresjs/tresjs.org/assets/20469369/92f811e9-7507-48bb-adb2-030eb708d5bb">

 