### PR TITLE
Update Header to redirect to Github repo instead of nuxt/ui

### DIFF
--- a/app/components/TheHeader.vue
+++ b/app/components/TheHeader.vue
@@ -17,7 +17,7 @@ const { headerLinks } = useHeaderLinks()
         <UButton
           color="neutral"
           variant="ghost"
-          to="https://github.com/nuxt/ui"
+          to="https://github.com/Tresjs/tres"
           target="_blank"
           icon="i-simple-icons-github"
           aria-label="GitHub"


### PR DESCRIPTION
Main page Github link was redirecting to `nuxt/ui` Github repo instead of `tres` repo.