### PR TITLE
fix: link github to TresJS orga

### DIFF
--- a/app/components/TheHeader.vue
+++ b/app/components/TheHeader.vue
@@ -17,7 +17,7 @@ const { headerLinks } = useHeaderLinks()
         <UButton
           color="neutral"
           variant="ghost"
-          to="https://github.com/nuxt/ui"
+          to="https://github.com/Tresjs"
           target="_blank"
           icon="i-simple-icons-github"
           aria-label="GitHub"


### PR DESCRIPTION
The github Link was pointing to still nuxt/ui. 


## Additional

Astro 👀 

<img width="555" height="248" alt="image" src="https://github.com/user-attachments/assets/23497f3d-6d65-44fa-b448-8620d30ade78" />

looks like tresjs.org is indexed with nuxt favicon

<img width="549" height="113" alt="image" src="https://github.com/user-attachments/assets/659c9f52-c0ff-4b65-82c8-ae6bce70d92a" />
